### PR TITLE
Allow the database connection and table name to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,16 @@
         * preview and remove files b4 uploading
         */
         'preview_files_before_upload' => true,
+          
+        /*
+         * Database connection (defaults to "mediamanager")
+         */
+        'database_connection' => 'mediamanager',
+        
+        /*
+         * Locked items table name (defaults to "locked")
+         */
+        'table_locked' => 'locked'  
     ];
     ```
 

--- a/src/Controllers/MediaController.php
+++ b/src/Controllers/MediaController.php
@@ -57,7 +57,7 @@ class MediaController extends Controller
         $this->storageDisk     = app('filesystem')->disk($this->fileSystem);
         $this->storageDiskInfo = app('config')->get("filesystems.disks.{$this->fileSystem}");
         $this->baseUrl         = $this->storageDisk->url('/');
-        $this->db              = app('db')->connection('mediamanager')->table('locked');
+        $this->db              = app('db')->connection($config['database_connection'] ?? 'mediamanager')->table($config['table_locked'] ?? 'locked');
 
         $this->storageDisk->addPlugin(new ListWith());
     }

--- a/src/config/mediaManager.php
+++ b/src/config/mediaManager.php
@@ -124,4 +124,14 @@ return [
      * preview and remove files b4 uploading
      */
     'preview_files_before_upload' => true,
+
+    /*
+     * Database connection (defaults to "mediamanager")
+     */
+    'database_connection' => 'mediamanager',
+
+    /*
+     * Locked items table name (defaults to "locked")
+     */
+    'table_locked' => 'locked'
 ];

--- a/src/database/migrations/2018_10_06_100234_create_media_manager_lock_list_table.php
+++ b/src/database/migrations/2018_10_06_100234_create_media_manager_lock_list_table.php
@@ -6,12 +6,19 @@ use Illuminate\Database\Migrations\Migration;
 
 class CreateMediaManagerLockListTable extends Migration
 {
+    protected $tableName;
+
+    public function __construct()
+    {
+        $this->tableName = config('mediaManager.table_locked', 'locked');
+    }
+
     /**
      * Run the migrations.
      */
     public function up()
     {
-        Schema::create('locked', function (Blueprint $table) {
+        Schema::create($this->tableName, function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('path');
         });
@@ -22,6 +29,6 @@ class CreateMediaManagerLockListTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('locked');
+        Schema::dropIfExists($this->tableName);
     }
 }


### PR DESCRIPTION
Instead of having to configure a seperate database connection just for this package, give the developer a choice in which connection and table name will be used. Backward compatible by the way.